### PR TITLE
Dev

### DIFF
--- a/lolakrakenpy/lola_kraken_iproov_services.py
+++ b/lolakrakenpy/lola_kraken_iproov_services.py
@@ -99,3 +99,39 @@ class LolaIproovServicesManager:
         
         except Exception as e:
             raise ValueError(e)
+    
+    def claimLinkCallback(self,returnUrl:str,theme:None,callback=None,develoment:bool=False,assuranceType = 'liveness',language='en'):
+        """
+        Claims a Link
+        
+        Args:
+            Link (str): The Link to claim.
+        Returns:
+            dict: The response JSON.
+        
+        """
+        try:
+                        
+            ## add to theme the key language
+            theme['language'] = language
+            metadata = {
+                'returnURL': returnUrl,
+                'operation': 'enrol',
+                'assuranceType': assuranceType,
+                'lolaURL': self.lola_kraken_url,
+                'theme': theme,
+                'callbackURL': callback
+            }            
+            endpoint = f'{self.lola_kraken_url}/pol/claim/link'
+            headers = {'x-lola-auth': self.lola_token, 'Content-Type': 'application/json'}
+            data = {
+                'baseUrl': None,
+                'metadata': metadata
+            }
+            data = claimTokenSchema(**data).model_dump(exclude_none=True)
+            response = requests.post(endpoint, headers=headers, json=data)
+            response.raise_for_status()
+            return response.json()
+        
+        except Exception as e:
+            raise ValueError(e)

--- a/lolakrakenpy/lola_kraken_iproov_services.py
+++ b/lolakrakenpy/lola_kraken_iproov_services.py
@@ -1,6 +1,6 @@
 import uuid
 import requests
-from lolakrakenpy.shemas.iproov_shema import claimTokenSchema
+from lolakrakenpy.shemas.iproov_shema import claimTokenSchema, claimTokenSchemaCallback
 
 class LolaIproovServicesManager:
     def __init__(self, session, lola_token, lola_kraken_url):
@@ -128,7 +128,7 @@ class LolaIproovServicesManager:
                 'baseUrl': None,
                 'metadata': metadata
             }
-            data = claimTokenSchema(**data).model_dump(exclude_none=True)
+            data = claimTokenSchemaCallback(**data).model_dump(exclude_none=True)
             response = requests.post(endpoint, headers=headers, json=data)
             response.raise_for_status()
             return response.json()

--- a/lolakrakenpy/lola_kraken_iproov_services.py
+++ b/lolakrakenpy/lola_kraken_iproov_services.py
@@ -100,7 +100,7 @@ class LolaIproovServicesManager:
         except Exception as e:
             raise ValueError(e)
     
-    def claimLinkCallback(self,returnUrl:str,theme:None,callback=None,develoment:bool=False,assuranceType = 'liveness',language='en'):
+    def claimLinkCallback(self,returnUrl:str,theme:None,callback=None,develoment:bool=False,assuranceType = 'liveness',language='en',conversationId:str=None):
         """
         Claims a Link
         
@@ -111,9 +111,14 @@ class LolaIproovServicesManager:
         
         """
         try:
+            if conversationId is None:
+                conversationId = str(uuid.uuid4())
                         
             ## add to theme the key language
             theme['language'] = language
+            sessionStore = {
+                'userId' : conversationId
+            }
             metadata = {
                 'returnURL': returnUrl,
                 'operation': 'enrol',
@@ -126,7 +131,9 @@ class LolaIproovServicesManager:
             headers = {'x-lola-auth': self.lola_token, 'Content-Type': 'application/json'}
             data = {
                 'baseUrl': None,
-                'metadata': metadata
+                'metadata': metadata,
+                'chatLead': {},
+                'sessionStore': sessionStore
             }
             data = claimTokenSchemaCallback(**data).model_dump(exclude_none=True)
             response = requests.post(endpoint, headers=headers, json=data)

--- a/lolakrakenpy/lola_kraken_utils_services.py
+++ b/lolakrakenpy/lola_kraken_utils_services.py
@@ -107,7 +107,7 @@ class LolaUtilsServicesManager:
         except Exception as e:
             raise ValueError(e)
 
-    def sendNotification(self, reqToken: str, label: str, payload):
+    def sendNotification(self, reqToken: str, label: str, payload,delay: int = 0):
         """
         Validates an address.
         Args:
@@ -118,6 +118,8 @@ class LolaUtilsServicesManager:
             dict: The response JSON.
         """
         try:
+            import time
+            time.sleep(delay)
             endpoint = f'{self.lola_kraken_url}/utils/sendnotification'
             headers = {
                 'Content-Type': 'application/json',
@@ -136,8 +138,8 @@ class LolaUtilsServicesManager:
 
         except Exception as e:
             raise ValueError(e)
-    def threadSendNotification(self, reqToken: str, label: str, payload):
-        threading.Thread(target=self.sendNotification, args=(reqToken, label, payload)).start()
+    def threadSendNotification(self, reqToken: str, label: str, payload, delay: int = 0):
+        threading.Thread(target=self.sendNotification, args=(reqToken, label, payload, delay)).start()
     def validateAddress(self, address: str):
         """
         Validates an address.

--- a/lolakrakenpy/shemas/iproov_shema.py
+++ b/lolakrakenpy/shemas/iproov_shema.py
@@ -13,3 +13,9 @@ class claimTokenSchema(BaseModel):
     chatLead: object | None
     sessionStore: object  | None
     metadata: metadataSchema | None
+
+class claimTokenSchemaCallback(BaseModel):
+    baseUrl: str | None
+    chatLead: object | None
+    sessionStore: object  | None
+    metadata: metadataSchema | None

--- a/lolakrakenpy/shemas/iproov_shema.py
+++ b/lolakrakenpy/shemas/iproov_shema.py
@@ -24,6 +24,4 @@ class claimTokenSchema(BaseModel):
 
 class claimTokenSchemaCallback(BaseModel):
     baseUrl: str | None
-    chatLead: object | None
-    sessionStore: object  | None
     metadata: metadataSchemaCallback | None

--- a/lolakrakenpy/shemas/iproov_shema.py
+++ b/lolakrakenpy/shemas/iproov_shema.py
@@ -25,3 +25,5 @@ class claimTokenSchema(BaseModel):
 class claimTokenSchemaCallback(BaseModel):
     baseUrl: str | None
     metadata: metadataSchemaCallback | None
+    chatLead: object | None
+    sessionStore: object  | None

--- a/lolakrakenpy/shemas/iproov_shema.py
+++ b/lolakrakenpy/shemas/iproov_shema.py
@@ -7,6 +7,14 @@ class metadataSchema(BaseModel):
     assuranceType: str | None
     lolaURL: str | None
     theme: object | None
+    
+class metadataSchemaCallback(BaseModel):
+    returnURL: str | None
+    operation: str | None
+    assuranceType: str | None
+    lolaURL: str | None
+    theme: object | None
+    callbackURL: str | None
 
 class claimTokenSchema(BaseModel):
     baseUrl: str | None
@@ -18,4 +26,4 @@ class claimTokenSchemaCallback(BaseModel):
     baseUrl: str | None
     chatLead: object | None
     sessionStore: object  | None
-    metadata: metadataSchema | None
+    metadata: metadataSchemaCallback | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lolakrakenpy"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Jorge Trujillo", email="jorge@leapfinancial.com" },
 ]


### PR DESCRIPTION
This pull request introduces new features and enhancements to the `lolakrakenpy` library, including support for callback functionality in claim links, improved notification handling, and schema updates. Additionally, the library version is incremented to `0.0.3`.

### New Features and Enhancements:

* **Callback Functionality for Claim Links**:
  - Added a new method `claimLinkCallback` in `LolaIproovServicesManager` to support callback URLs and additional metadata for claim links. This includes handling of `assuranceType`, `language`, and `conversationId`. (`[lolakrakenpy/lola_kraken_iproov_services.pyR102-R144](diffhunk://#diff-a1ed64ba482cbeca8200704d18353475778a4c5d3eae3894e64aa09627d45368R102-R144)`)
  - Updated import in `lola_kraken_iproov_services.py` to include the new `claimTokenSchemaCallback`. (`[lolakrakenpy/lola_kraken_iproov_services.pyL3-R3](diffhunk://#diff-a1ed64ba482cbeca8200704d18353475778a4c5d3eae3894e64aa09627d45368L3-R3)`)

* **Notification Handling**:
  - Enhanced `sendNotification` method in `lola_kraken_utils_services.py` to include an optional `delay` parameter for delayed notifications. (`[[1]](diffhunk://#diff-0022c70d7c8210705e8184c7b94e7d2845ac4c00287df9267ddf4b1a1d3f31d9L110-R110)`, `[[2]](diffhunk://#diff-0022c70d7c8210705e8184c7b94e7d2845ac4c00287df9267ddf4b1a1d3f31d9R121-R122)`)
  - Updated `threadSendNotification` to support the new `delay` parameter. (`[lolakrakenpy/lola_kraken_utils_services.pyL139-R142](diffhunk://#diff-0022c70d7c8210705e8184c7b94e7d2845ac4c00287df9267ddf4b1a1d3f31d9L139-R142)`)

### Schema Updates:

* Added `metadataSchemaCallback` and `claimTokenSchemaCallback` classes in `iproov_shema.py` to support the new callback functionality and metadata structure. (`[lolakrakenpy/shemas/iproov_shema.pyR11-R29](diffhunk://#diff-bcfda18c12d14912b755487b38fb1513caef9736b4e0586f1e23eec4ab64514eR11-R29)`)

### Version Update:

* Incremented the library version from `0.0.2` to `0.0.3` in `pyproject.toml` to reflect the new features. (`[pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)`)